### PR TITLE
Fix curse only applying to non-respawns

### DIFF
--- a/common/src/main/java/com/redpxnda/respawnobelisks/registry/block/RespawnObeliskBlock.java
+++ b/common/src/main/java/com/redpxnda/respawnobelisks/registry/block/RespawnObeliskBlock.java
@@ -185,7 +185,7 @@ public class RespawnObeliskBlock extends Block implements BlockEntityProvider {
 
             boolean hasPlayedCurseAnim = false;
             if (RespawnObelisksConfig.INSTANCE.immortalityCurse.enableCurse && (charge-cost < 0 || forceCurse) && shouldCost) { // if cost brings charge below 0, curse
-                boolean applyCurse = isTeleport || player.isAlive();
+                boolean applyCurse = !(isTeleport || player.isAlive());
                 int amplifier = applyCurse ?
                         (
                                 mei != null ?


### PR DESCRIPTION
`RespawnObeliskBlock#getRespawnLocation` currently applies the Immortality Curse if `isTeleport || player.isAlive()` instead of `!(isTeleport || player.isAlive())`.  This PR fixes that.

Essentially, this PR just makes the curse apply to respawning targets like the mod page says instead of only teleporting targets.